### PR TITLE
refactor(repo): Add gtest/gmock support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,15 @@ set(CMAKE_CXX_CLANG_FORMAT "clang-format")
 set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "iwyu")
 
 set(SRC_DIR src)
+set(TEST_DIR test)
 
 file(GLOB_RECURSE ALL_SOURCE_FILES 
     ${CMAKE_SOURCE_DIR}/${SRC_DIR}/*.cpp 
     ${CMAKE_SOURCE_DIR}/${SRC_DIR}/*.c
     ${CMAKE_SOURCE_DIR}/${SRC_DIR}/*.h
+    ${CMAKE_SOURCE_DIR}/${TEST_DIR}/*.cpp
+    ${CMAKE_SOURCE_DIR}/${TEST_DIR}/*.c
+    ${CMAKE_SOURCE_DIR}/${TEST_DIR}/*.h
 )
 
 add_custom_target(fix
@@ -29,3 +33,13 @@ add_custom_target(fix
 
 add_subdirectory(src)
 add_subdirectory(test)
+
+add_custom_target(test
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running tests..."
+    DEPENDS test_runner
+)
+
+add_dependencies(test_runner fix)
+add_dependencies(test test_runner)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,5 @@ RUN apt install -y iwyu
 
 RUN printf "\nalias ls='ls --color=auto'\n" >> ~/.bashrc
 RUN printf "\nalias ll='ls -alF'\n" >> ~/.bashrc
+
+WORKDIR /workspace

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -7,11 +7,14 @@
  */
 
 #include <common.h>
+
 #include <iostream>
 
 int Common::talk() {
-  std::cout << "hello!" << std::endl;
-  return 0;
+    std::cout << "hello!" << std::endl;
+    return 0;
 }
 
-int Common::add(int a, int b) { return a + b; }
+int Common::add(int a, int b) {
+    return a + b;
+}

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -2,19 +2,15 @@
 #ifndef __COMMON_H
 #define __COMMON_H
 
-
 class Common {
-
-public:
-
+   public:
     Common() {}
     ~Common() {}
 
     int talk(void);
     int add(int a, int b);
 
-private:
-
+   private:
 };
 
-#endif // __COMMON_H
+#endif  // __COMMON_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <common.h>
+
 #include <iostream>
 
 /**
@@ -13,11 +14,11 @@
  */
 
 int main() {
-  Common c;
+    Common c;
 
-  std::cout << "Hello C++ Template!" << std::endl;
+    std::cout << "Hello C++ Template!" << std::endl;
 
-  c.talk();
+    c.talk();
 
-  return 0;
+    return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,18 +1,41 @@
-set(TEST_NAME test_suite)
+cmake_minimum_required(VERSION 3.18)
 
-set(LIB_DIR lib)
-set(FAKEIT_DIR FakeIt)
-
-include_directories(
-  ${CMAKE_SOURCE_DIR}/${LIB_DIR}/${FAKEIT_DIR}
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        v1.14.0
 )
-  
-set(Sources 
-  main_test.cpp
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+foreach(target IN ITEMS gtest gtest_main gmock gmock_main)
+    if(TARGET ${target})
+        set_target_properties(${target} PROPERTIES 
+        CXX_CLANG_TIDY ""
+        CXX_INCLUDE_WHAT_YOU_USE "")
+    endif()
+endforeach()
+
+enable_testing()
+
+add_executable(test_runner main_test.cpp)
+
+target_link_libraries(test_runner 
+    PRIVATE 
+    common
+    GTest::gtest
+    GTest::gtest_main
 )
 
-## Testing 
-find_package(Catch2 3 REQUIRED)
+target_include_directories(test_runner PRIVATE 
+    ${CMAKE_SOURCE_DIR}/src/common
+)
 
-add_executable(${TEST_NAME} ${Sources})
-target_link_libraries(${TEST_NAME} PRIVATE Catch2::Catch2WithMain)
+set_target_properties(test_runner PROPERTIES
+    CXX_CLANG_TIDY ""
+    CXX_INCLUDE_WHAT_YOU_USE ""
+)
+
+# Add test to CTest
+add_test(NAME CXX_Template_Tests COMMAND test_runner)

--- a/test/main_test.cpp
+++ b/test/main_test.cpp
@@ -1,9 +1,37 @@
-#include <catch2/catch_test_macros.hpp>
-#include <fakeit.hpp>
+/**
+ * @file main_test.cpp
+ * @brief Test file for CXX Template project
+ * @author rouxfederico@gmail.com
+ */
 
-TEST_CASE("dummy test", "[C++ Template]") {
-  int i = 0;
+#include <common.h>
+#include <gtest/gtest.h>  // NOLINT
 
-  INFO("Basic info from test app: " << i);
-  REQUIRE(true);
+/**
+ * @brief Test case for Common::add function
+ */
+TEST(CommonTest, AddTest) {
+    Common c;
+    EXPECT_EQ(c.add(2, 3), 5);
+    EXPECT_EQ(c.add(0, 0), 0);
+    EXPECT_EQ(c.add(-1, 1), 0);
+    EXPECT_EQ(c.add(10, -5), 5);
+}
+
+/**
+ * @brief Test case for Common::talk function
+ */
+TEST(CommonTest, TalkTest) {
+    Common c;
+    // talk() returns 0 on success
+    EXPECT_EQ(c.talk(), 0);
+}
+
+/**
+ * @brief Test case for Common object creation
+ */
+TEST(CommonTest, ConstructorTest) {
+    Common c;
+    // Object should be created successfully
+    SUCCEED();
 }


### PR DESCRIPTION
refactor(repo): Add gtest/gmock support

Closes #8

This PR adds a minimal support to use gtest/mock

Signed-off-by: Federico Roux <rouxfederico@gmail.com>