### PR TITLE
hotfix(repo): add tests to `make test` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,10 @@ add_custom_target(fix
     COMMENT "Running clang-format to fix formatting..."
 )
 
+# Enable testing (must be called before add_subdirectory for test)
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(test)
 
-add_custom_target(test
-    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMENT "Running tests..."
-    DEPENDS test_runner
-)
-
 add_dependencies(test_runner fix)
-add_dependencies(test test_runner)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,6 @@ foreach(target IN ITEMS gtest gtest_main gmock gmock_main)
     endif()
 endforeach()
 
-enable_testing()
-
 add_executable(test_runner main_test.cpp)
 
 target_link_libraries(test_runner 
@@ -37,5 +35,4 @@ set_target_properties(test_runner PROPERTIES
     CXX_INCLUDE_WHAT_YOU_USE ""
 )
 
-# Add test to CTest
-add_test(NAME CXX_Template_Tests COMMAND test_runner)
+add_test(NAME CXX_Template_Tests COMMAND $<TARGET_FILE:test_runner>)

--- a/test/main_test.cpp
+++ b/test/main_test.cpp
@@ -23,7 +23,6 @@ TEST(CommonTest, AddTest) {
  */
 TEST(CommonTest, TalkTest) {
     Common c;
-    // talk() returns 0 on success
     EXPECT_EQ(c.talk(), 0);
 }
 
@@ -32,6 +31,5 @@ TEST(CommonTest, TalkTest) {
  */
 TEST(CommonTest, ConstructorTest) {
     Common c;
-    // Object should be created successfully
     SUCCEED();
 }


### PR DESCRIPTION
hotfix(repo): add tests to `make test` target

This PR adds the tests in [`test`](./test) to the `make test` target,
that wasn't registered in the previous PR.

Tested by running failing tests and repairing them

Signed-off-by: Federico Roux <rouxfederico@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgr-17/CXX-Template/12)
<!-- Reviewable:end -->
