### PR TITLE
hotfix(repo): add tests to `make test` target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,15 +31,10 @@ add_custom_target(fix
     COMMENT "Running clang-format to fix formatting..."
 )
 
+# Enable testing (must be called before add_subdirectory for test)
+enable_testing()
+
 add_subdirectory(src)
 add_subdirectory(test)
 
-add_custom_target(test
-    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMENT "Running tests..."
-    DEPENDS test_runner
-)
-
 add_dependencies(test_runner fix)
-add_dependencies(test test_runner)

--- a/README.md
+++ b/README.md
@@ -29,58 +29,40 @@ docker exec -it cxx-template bash
 CMake has built-in features to connect with code quality tools and analyze the code that is being compiled.
 In the current version of this repo, the following tools has been configured:
 
-* cpplint
 * clang-tidy
 * clang-format
 * iwyu
 
 Those tools are triggered from CMake in the following lines on the general CMakeLists.txt
 
-```cmake
-set(CMAKE_CXX_CPPLINT "cpplint")
+~~~CMake
 set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
 set(CMAKE_CXX_CLANG_FORMAT "clang-format")
 set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "iwyu")
-```
+~~~
+
+If you run into clang-tidy issues, there's a `make fix` target that can do the work for you
 
 ## Test suite
 
-Unit test are based on Catch2 and FakeIt. These libs are added as submodules. Be sure to clone the repository using
+Unit test are based on gtest and gmock. To run tests, jump into the container and run:
 
-```git
-git clone <URL> --recursive
-```
-
-Or once the repository was cloned, then run:
-
-```git
-git submodule update --init
-```
-
-Catch2 needs to be installed on the container. This can be easily done by executing:
-
-```bash
-cd scripts
-./install-catch2.sh
-```
+~~~bash
+cd build
+cmake ..
+make test
+~~~
 
 ## Building the sources:
 
-This project is based on cmake. In order to simplify the process, a script called <build-all.sh> is provided. It's a bash script, so it can be run inside the container, or on a Unix-macOS environment. This script will generate all the building files and the docs (based on doxygen). Just run:
+This project is based on CMake. To compile everything 
 
-```bash
-cd scripts
-./build-all.sh
-```
-
-To compile natively on Windows, please open a cmd.exe or PowerShell terminal, cd into the project folder and run:
-
-```
+~~~bash
 mkdir -p build
 cd build
-cmake ..\
-
-```
+cmake ..
+make
+~~~
 
 The executable files can be found at:
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,6 @@ foreach(target IN ITEMS gtest gtest_main gmock gmock_main)
     endif()
 endforeach()
 
-enable_testing()
-
 add_executable(test_runner main_test.cpp)
 
 target_link_libraries(test_runner 
@@ -37,5 +35,4 @@ set_target_properties(test_runner PROPERTIES
     CXX_INCLUDE_WHAT_YOU_USE ""
 )
 
-# Add test to CTest
-add_test(NAME CXX_Template_Tests COMMAND test_runner)
+add_test(NAME CXX_Template_Tests COMMAND $<TARGET_FILE:test_runner>)

--- a/test/main_test.cpp
+++ b/test/main_test.cpp
@@ -23,7 +23,6 @@ TEST(CommonTest, AddTest) {
  */
 TEST(CommonTest, TalkTest) {
     Common c;
-    // talk() returns 0 on success
     EXPECT_EQ(c.talk(), 0);
 }
 
@@ -32,6 +31,5 @@ TEST(CommonTest, TalkTest) {
  */
 TEST(CommonTest, ConstructorTest) {
     Common c;
-    // Object should be created successfully
     SUCCEED();
 }


### PR DESCRIPTION
hotfix(repo): add tests to `make test` target

This PR adds the tests in [`test`](./test) to the `make test` target,
that wasn't registered in the previous PR.

Tested by running failing tests and repairing them

Signed-off-by: Federico Roux <rouxfederico@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgr-17/CXX-Template/13)
<!-- Reviewable:end -->
