### PR TITLE
feature(repo): add `valgrind` support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "enable/disable compiler specific extens
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -W -Wall -Wextra -Werror")
 
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+endif()
+
+include(${CMAKE_SOURCE_DIR}/cmake/Valgrind.cmake)
 
 set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
 set(CMAKE_CXX_CLANG_FORMAT "clang-format")
@@ -38,3 +43,13 @@ add_subdirectory(src)
 add_subdirectory(test)
 
 add_dependencies(test_runner fix)
+
+if(VALGRIND_EXECUTABLE)
+    add_valgrind_check(test_runner)
+
+    add_custom_target(valgrind
+        COMMAND ${CMAKE_CTEST_COMMAND} -L valgrind --output-on-failure
+        DEPENDS test_runner cxx_app
+        COMMENT "Running Valgrind memory checks via CTest"
+    )
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt install -y clang-format
 RUN apt install -y git
 RUN apt install -y clang-tidy
 RUN apt install -y iwyu
+RUN apt install -y valgrind
 
 RUN printf "\nalias ls='ls --color=auto'\n" >> ~/.bashrc
 RUN printf "\nalias ll='ls -alF'\n" >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In the current version of this repo, the following tools has been configured:
 * clang-tidy
 * clang-format
 * iwyu
+* valgrind (memory checks, container only)
 
 Those tools are triggered from CMake in the following lines on the general CMakeLists.txt
 
@@ -42,6 +43,25 @@ set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "iwyu")
 ~~~
 
 If you run into clang-tidy issues, there's a `make fix` target that can do the work for you
+
+### Valgrind
+
+Valgrind is installed in the Docker image only (not required on the host). After building inside the container, run memory checks with:
+
+~~~bash
+cd build
+cmake ..
+make
+make valgrind
+~~~
+
+Or run only the Valgrind CTest entries:
+
+~~~bash
+ctest -L valgrind --output-on-failure
+~~~
+
+Build with debug symbols (the default `CMAKE_BUILD_TYPE=Debug`) for useful Valgrind stack traces.
 
 ## Test suite
 
@@ -67,4 +87,4 @@ make
 The executable files can be found at:
 
 - app: build/src/cxx_app
-- test suite: build/test/test_suite
+- test suite: build/test/test_runner

--- a/cmake/Valgrind.cmake
+++ b/cmake/Valgrind.cmake
@@ -1,0 +1,29 @@
+find_program(VALGRIND_EXECUTABLE NAMES valgrind)
+
+set(VALGRIND_SUPPRESSIONS_FILE
+    "${CMAKE_SOURCE_DIR}/cmake/valgrind.supp"
+    CACHE FILEPATH "Valgrind suppressions file")
+
+set(VALGRIND_OPTIONS
+    --error-exitcode=1
+    --leak-check=full
+    --show-leak-kinds=all
+    --track-origins=yes
+)
+
+if(EXISTS "${VALGRIND_SUPPRESSIONS_FILE}")
+    list(APPEND VALGRIND_OPTIONS --suppressions=${VALGRIND_SUPPRESSIONS_FILE})
+endif()
+
+function(add_valgrind_check target)
+    if(NOT VALGRIND_EXECUTABLE)
+        return()
+    endif()
+
+    set(test_name "valgrind_${target}")
+    add_test(
+        NAME ${test_name}
+        COMMAND ${VALGRIND_EXECUTABLE} ${VALGRIND_OPTIONS} $<TARGET_FILE:${target}>
+    )
+    set_tests_properties(${test_name} PROPERTIES LABELS "valgrind")
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,3 +6,7 @@ add_subdirectory(common)
 
 add_executable (${app_name} main.cpp)
 target_link_libraries(${app_name} common)
+
+if(VALGRIND_EXECUTABLE)
+    add_valgrind_check(${app_name})
+endif()


### PR DESCRIPTION
Stacked PRs:
 * __->__#15


--- --- ---

### feature(repo): add `valgrind` support


Closes #14

Add Valgrind mem leak support and integrate it with the current CMake
and Makefile targets

Signed-off-by: Federico Roux <rouxfederico@gmail.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fgr-17/CXX-Template/15)
<!-- Reviewable:end -->
